### PR TITLE
Quick way of checking if some headers were invalid in `addHeaders`

### DIFF
--- a/lib/spvchain.js
+++ b/lib/spvchain.js
@@ -142,9 +142,7 @@ const SpvChain = class {
 
   addHeaders(headers) {
     const self = this;
-    const allAdded = headers.reduce((acc, header) => {
-      return acc && self.addHeader(header);
-    }, true);
+    const allAdded = headers.reduce((acc, header) => acc && self.addHeader(header), true);
 
     if (!allAdded) {
       throw new Error('Some headers are invalid');

--- a/lib/spvchain.js
+++ b/lib/spvchain.js
@@ -142,9 +142,13 @@ const SpvChain = class {
 
   addHeaders(headers) {
     const self = this;
-    headers.forEach((header) => {
-      self.addHeader(header);
-    });
+    const allAdded = headers.reduce((acc, header) => {
+      return acc && self.addHeader(header);
+    }, true);
+
+    if (!allAdded) {
+      throw new Error('Some headers are invalid');
+    }
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,16 @@ describe('SPV-DASH (forks & re-orgs)', () => {
     chain.addHeader(headers[25]);
     chain.getLongestChain().length.should.equal(26);
   });
+
+  it('should throw an error if some of the headers is invalid', (done) => {
+    try {
+      chain.addHeaders([headers[25], headers[10]]);
+      done(new Error('SPV chain failed to throw an error on invalid block'));
+    } catch (e) {
+      e.message.should.equal('Some headers are invalid');
+      done();
+    }
+  });
 });
 
 let genesisHash = null;

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ describe('SPV-DASH (forks & re-orgs)', () => {
   });
 
   it('add remaining test headers', () => {
-    chain.addHeaders(headers.slice(3));
+    chain.addHeaders(headers.slice(3, 25));
     chain.getOrphans().length.should.equal(0);
     chain.getAllBranches().length.should.equal(1);
     chain.getLongestChain().length.should.equal(26);


### PR DESCRIPTION
Small change which uses return value of the `addHeader` method, to define if some of the headers were invalid and haven't been added.