### PR TITLE
feat: get block header by hash + store by height

### DIFF
--- a/lib/blockstore.js
+++ b/lib/blockstore.js
@@ -1,6 +1,5 @@
 const levelup = require('levelup');
 const memdown = require('memdown');
-const dashcore = require('@dashevo/dashcore-lib');
 
 class BlockStore {
   constructor() {
@@ -9,14 +8,24 @@ class BlockStore {
       valueAsBuffer: false,
       valueEncoding: 'json',
     });
-    this.block = dashcore.BlockHeader;
   }
 
+  /**
+   * Allow to store an header
+   * @param header
+   * @returns {Promise<String>}
+   */
   put(header) {
     return new Promise((resolve, reject) => {
       this.db.put(header.hash, JSON.stringify(header.toObject()), (err) => {
         if (!err) {
-          resolve(header.hash);
+          this.db.put(header.height, header.hash, (heightError) => {
+            if (!heightError) {
+              resolve(header.hash);
+            } else {
+              reject(heightError);
+            }
+          });
         } else {
           reject(err);
         }
@@ -24,17 +33,25 @@ class BlockStore {
     });
   }
 
-  get(hash) {
+  /**
+   * Allow to get back an header by it's hash or height
+   *
+   * @param {String|Number} identifier - Hash or height block identifier
+   * @returns {Promise<BlockHeader>}
+   */
+  get(identifier) {
     const self = this;
 
     return new Promise((resolve, reject) => {
-      self.db.get(hash, (err, data) => {
+      self.db.get(identifier, (err, data) => {
         if (err && err.name === 'NotFoundError') {
           resolve(null);
         } else if (err) {
           reject(err.message);
         } else {
-          resolve(JSON.parse(data.toString()));
+          resolve((identifier.constructor === Number)
+            ? self.get(JSON.parse(data.toString))
+            : JSON.parse(data.toString()));
         }
       });
     });


### PR DESCRIPTION
## Issue being fixed or feature implemented

This PR allow to store and fetch BlockHeader by their height. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
